### PR TITLE
Corrected error when parsing color in css_parser.dart

### DIFF
--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -74,7 +74,7 @@ class ExpressionMapping {
     var text = _text.replaceFirst('#', '');
     if (text.length == 3)
       text = text.replaceAllMapped(
-          RegExp(r"[a-f]|\d"), (match) => '${match.group(0)}${match.group(0)}');
+          RegExp(r"[a-f]|\d", caseSensitive: false), (match) => '${match.group(0)}${match.group(0)}');
     int color = int.parse(text, radix: 16);
 
     if (color <= 0xffffff) {


### PR DESCRIPTION
When parsing hex color with a length of 3, if the hex value wasn't lower case it didn't convert correctly to a hex of length 6